### PR TITLE
Hide unresolved subdomain entries and remove misleading counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,6 @@
 
         <div id="stats" class="stats" style="display: none;">
             <div class="stat-item">
-                <div class="stat-number" id="totalFound">0</div>
-                <div class="stat-label">Subdominios encontrados</div>
-            </div>
-            <div class="stat-item">
                 <div class="stat-number" id="activeCount">0</div>
                 <div class="stat-label">Activos</div>
             </div>

--- a/style.css
+++ b/style.css
@@ -198,11 +198,6 @@
             color: #00b894;
         }
 
-        .status-not-found {
-            background: #fab1a0;
-            color: #e17055;
-        }
-
         .status-unknown {
             background: #9ca3af;
             color: #ffffff;


### PR DESCRIPTION
## Summary
- remove the misleading "Subdominios encontrados" statistic and keep only active and progress metrics
- stop tracking unfound subdomains and drop "not found" status handling
- eliminate CSS for the unused `status-not-found` badge

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b35618ba1083218800e3d7203448fe