### PR TITLE
Remove wordlist-based enumeration and use public APIs

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,30 +1,3 @@
-// Lista común de subdominios para verificar
-const commonSubdomains = [
-    'www', 'mail', 'ftp', 'localhost', 'webmail', 'smtp', 'pop', 'ns1', 'webdisk', 'ns2',
-    'cpanel', 'whm', 'autodiscover', 'autoconfig', 'ns', 'test', 'api', 'app', 'admin',
-    'blog', 'dev', 'staging', 'beta', 'alpha', 'demo', 'docs', 'help', 'support', 'portal',
-    'secure', 'shop', 'store', 'cdn', 'assets', 'images', 'img', 'static', 'media',
-    'mobile', 'm', 'api2', 'api1', 'web', 'old', 'new', 'backup', 'server', 'vpn',
-    'remote', 'ssh', 'sftp', 'mysql', 'db', 'database', 'panel', 'git', 'repo',
-    'jenkins', 'gitlab', 'jira', 'confluence', 'wiki', 'forum', 'community', 'status',
-    'monitor', 'nagios', 'zabbix', 'grafana', 'prometheus', 'elastic', 'kibana', 'logstash',
-    'search', 'solr', 'elasticsearch', 'redis', 'cache', 'memcached', 'rabbitmq', 'kafka',
-    'jenkins', 'ci', 'cd', 'build', 'deploy', 'docker', 'kubernetes', 'k8s', 'registry',
-    'nexus', 'artifactory', 'sonar', 'sonarqube', 'quality', 'qa', 'uat', 'prod',
-    'production', 'development', 'local', 'services', 'microservices', 'gateway', 'proxy',
-    'lb', 'loadbalancer', 'balancer', 'firewall', 'waf', 'ids', 'ips', 'siem',
-    'auth', 'oauth', 'sso', 'login', 'signin', 'signup', 'register', 'account', 'accounts',
-    'user', 'users', 'profile', 'profiles', 'dashboard', 'console', 'manager', 'crm',
-    'erp', 'hr', 'finance', 'accounting', 'billing', 'invoice', 'payment', 'payments',
-    'checkout', 'cart', 'order', 'orders', 'customer', 'customers', 'client', 'clients',
-    'partner', 'partners', 'vendor', 'vendors', 'supplier', 'suppliers', 'contractor',
-    'download', 'downloads', 'upload', 'uploads', 'file', 'files', 'share', 'cloud',
-    'storage', 'backup', 'archive', 'archives', 'vault', 'secure', 'private', 'public',
-    'internal', 'external', 'extranet', 'intranet', 'owa', 'exchange', 'outlook', 'mail1',
-    'mail2', 'mx', 'mx1', 'mx2', 'email', 'newsletter', 'campaign', 'marketing', 'seo',
-    'analytics', 'stats', 'statistics', 'metrics', 'reports', 'reporting', 'data',
-    'bigdata', 'ai', 'ml', 'machinelearning', 'deeplearning', 'tensorflow', 'pytorch'
-];
 
 let isScanning = false;
 const foundSubdomains = new Set();
@@ -71,10 +44,7 @@ async function startScan() {
     button.disabled = true;
     button.innerHTML = 'Escaneando <span class="spinner"></span>';
 
-    await Promise.all([
-        fetchSubdomainsFromAPIs(domain),
-        checkCommonSubdomains(domain)
-    ]);
+    await fetchSubdomainsFromAPIs(domain);
 
     isScanning = false;
     button.disabled = false;
@@ -84,11 +54,15 @@ async function startScan() {
 async function fetchSubdomainsFromAPIs(domain) {
     const services = [
         `https://jldc.me/anubis/subdomains/${domain}`,
-        `https://crt.sh/?q=%25.${domain}&output=json`
+        `https://crt.sh/?q=%25.${domain}&output=json`,
+        `https://dns.bufferover.run/dns?q=.${domain}`,
+        `https://api.hackertarget.com/hostsearch/?q=${domain}`,
+        `https://sonar.omnisint.io/subdomains/${domain}`
     ];
 
-    for (const service of services) {
-        if (!isScanning) break;
+    const total = services.length;
+    for (let i = 0; i < total && isScanning; i++) {
+        const service = services[i];
         try {
             const response = await fetch(service);
             if (!response.ok) continue;
@@ -97,6 +71,8 @@ async function fetchSubdomainsFromAPIs(domain) {
         } catch (err) {
             console.log(`Service ${service} failed:`, err);
         }
+        const progress = Math.round(((i + 1) / total) * 100);
+        document.getElementById('scanProgress').textContent = `${progress}%`;
     }
 }
 
@@ -110,6 +86,17 @@ function processServiceData(service, data, domain) {
             json.forEach((entry) => {
                 entry.name_value.split('\n').forEach((name) => subs.push(name.trim()));
             });
+        } else if (service.includes('bufferover')) {
+            const json = JSON.parse(data);
+            const entries = [...(json.FDNS_A || []), ...(json.RDNS || []), ...(json.FDNS_CNAME || [])];
+            entries.forEach((item) => {
+                const parts = item.split(',');
+                if (parts[1]) subs.push(parts[1]);
+            });
+        } else if (service.includes('hackertarget')) {
+            subs = data.split('\n').map((line) => line.split(',')[0]);
+        } else if (service.includes('omnisint')) {
+            subs = JSON.parse(data);
         }
     } catch (e) {
         const regex = new RegExp(`([a-zA-Z0-9.-]+\\.)${domain.replace('.', '\\.')}`, 'gi');
@@ -121,17 +108,6 @@ function processServiceData(service, data, domain) {
             addSubdomainToResults(sub);
         }
     });
-}
-
-async function checkCommonSubdomains(domain) {
-    const total = commonSubdomains.length;
-    for (let i = 0; i < total && isScanning; i++) {
-        const subdomain = `${commonSubdomains[i]}.${domain}`;
-        addSubdomainToResults(subdomain);
-        const progress = Math.round(((i + 1) / total) * 100);
-        document.getElementById('scanProgress').textContent = `${progress}%`;
-        await new Promise((r) => setTimeout(r, 50));
-    }
 }
 
 function addSubdomainToResults(subdomain) {


### PR DESCRIPTION
## Summary
- eliminate hardcoded wordlist scanning
- enumerate subdomains via public APIs (anubis, crt.sh, bufferover, hackertarget, omnisint)
- track scan progress per service

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b3574990d08321a2a93c61500b0269