### PR TITLE
Add button for manual subdomain validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         </div>
 
         <button id="copyButton" style="display: none; margin: 10px 0;">Copiar</button>
+        <button id="validateButton" style="display: none; margin: 10px 0;">Validar</button>
 
         <div id="results" class="results"></div>
     </div>

--- a/script.js
+++ b/script.js
@@ -18,6 +18,7 @@ document.getElementById('domainInput').addEventListener('keypress', (e) => {
     }
 });
 document.getElementById('copyButton').addEventListener('click', copyResults);
+document.getElementById('validateButton').addEventListener('click', validateAllSubdomains);
 
 function resetUI() {
     document.getElementById('results').innerHTML = '';
@@ -25,6 +26,7 @@ function resetUI() {
     document.getElementById('scanProgress').textContent = '0%';
     document.getElementById('stats').style.display = 'flex';
     document.getElementById('copyButton').style.display = 'none';
+    document.getElementById('validateButton').style.display = 'none';
     activeCount = 0;
 }
 
@@ -71,9 +73,9 @@ async function fetchSubdomainsFromFunction(domain) {
         }
         const subs = await response.json();
         subs.forEach((sub) => addSubdomainToResults(sub));
-        validateAllSubdomains();
         document.getElementById('scanProgress').textContent = '100%';
         document.getElementById('copyButton').style.display = subs.length ? 'block' : 'none';
+        document.getElementById('validateButton').style.display = subs.length ? 'block' : 'none';
     } catch (err) {
         showError('No se pudo completar el escaneo');
     }


### PR DESCRIPTION
## Summary
- add button to manually validate subdomains after scanning
- wire button to existing validation function and manage visibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b36899ad308321bcfe54f7563f68dc