### PR TITLE
Increase Netlify scan function timeout

### DIFF
--- a/netlify/functions/scan.js
+++ b/netlify/functions/scan.js
@@ -1,3 +1,7 @@
+exports.config = {
+  maxDuration: 26
+};
+
 exports.handler = async function (event) {
   const domain = event.queryStringParameters?.domain;
   if (!domain) {


### PR DESCRIPTION
## Summary
- Extend scan function execution time to Netlify's 26-second maximum

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b375d65dcc8321b175d7432490cebb