### PR TITLE
fix: replace non-responsive image URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Descubre subdominios de cualquier dominio con nuestra herramienta DNS Scanner.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://example.com">
-    <meta property="og:image" content="https://via.placeholder.com/1200x630.png?text=DNS+Scanner">
+    <meta property="og:image" content="https://placehold.co/1200x630/png?text=DNS+Scanner">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="DNS Subdomain Scanner">
     <meta name="twitter:description" content="Descubre subdominios de cualquier dominio con nuestra herramienta DNS Scanner.">
-    <meta name="twitter:image" content="https://via.placeholder.com/1200x630.png?text=DNS+Scanner">
+    <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=DNS+Scanner">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace broken meta image URL with functioning placeholder

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b76f809483218c660ace71411e77