### PR TITLE
Add basic security headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
     <meta name="twitter:title" content="DNS Subdomain Scanner">
     <meta name="twitter:description" content="Descubre subdominios de cualquier dominio con nuestra herramienta DNS Scanner.">
     <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=DNS+Scanner">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta name="referrer" content="same-origin">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://placehold.co data:; connect-src 'self';">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,10 @@
 [build]
   publish = "."
   functions = "netlify/functions"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "same-origin"
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://placehold.co data:; connect-src 'self';"


### PR DESCRIPTION
## Summary
- add meta tags for X-Content-Type-Options, Referrer Policy and Content Security Policy
- configure Netlify to send security headers

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68b4f4d1f740832190415e45ddb0a019