### PR TITLE
Fortify Content Security Policy with base-uri and object-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:image" content="https://placehold.co/1200x630/png?text=DNS+Scanner">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta name="referrer" content="same-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://placehold.co data:; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://placehold.co data:; connect-src 'self'; base-uri 'self'; object-src 'none';">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
   [headers.values]
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "same-origin"
-    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://placehold.co data:; connect-src 'self';"
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://placehold.co data:; connect-src 'self'; base-uri 'self'; object-src 'none';"


### PR DESCRIPTION
## Summary
- restrict base tag usage via CSP base-uri 'self'
- block plugin content by adding CSP object-src 'none'

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f73a0180832192457c5acc3ebfe3